### PR TITLE
Fix shellcheck lint errors in Kubemark scripts

### DIFF
--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -21,7 +21,7 @@ import {ViewEncapsulation} from './metadata/view';
 export {Attribute} from './di';
 export {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, DoCheck, OnChanges, OnDestroy, OnInit} from './interface/lifecycle_hooks';
 export {ANALYZE_FOR_ENTRY_COMPONENTS, ContentChild, ContentChildDecorator, ContentChildren, ContentChildrenDecorator, Query, ViewChild, ViewChildDecorator, ViewChildren, ViewChildrenDecorator} from './metadata/di';
-export {Component, ComponentDecorator, Directive, DirectiveDecorator, HostBinding, HostListener, Input, Output, Pipe} from './metadata/directives';
+export {Component, ComponentDecorator, Directive, DirectiveDecorator, HostBinding, HostBindingDecorator, HostListener, HostListenerDecorator, Input, InputDecorator, Output, OutputDecorator, Pipe, PipeDecorator} from './metadata/directives';
 export {DoBootstrap, ModuleWithProviders, NgModule} from './metadata/ng_module';
 export {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata} from './metadata/schema';
 export {ViewEncapsulation} from './metadata/view';

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -359,6 +359,11 @@ export interface HostBinding {
 
 export declare const HostBinding: HostBindingDecorator;
 
+export interface HostBindingDecorator {
+    (hostPropertyName?: string): any;
+    new (hostPropertyName?: string): any;
+}
+
 export interface HostDecorator {
     (): any;
     new (): Host;
@@ -370,6 +375,11 @@ export interface HostListener {
 }
 
 export declare const HostListener: HostListenerDecorator;
+
+export interface HostListenerDecorator {
+    (eventName: string, args?: string[]): any;
+    new (eventName: string, args?: string[]): any;
+}
 
 export declare function inject<T>(token: Type<T> | InjectionToken<T>): T;
 export declare function inject<T>(token: Type<T> | InjectionToken<T>, flags?: InjectFlags): T | null;
@@ -451,6 +461,11 @@ export interface Input {
 }
 
 export declare const Input: InputDecorator;
+
+export interface InputDecorator {
+    (bindingPropertyName?: string): any;
+    new (bindingPropertyName?: string): any;
+}
 
 export declare function isDevMode(): boolean;
 
@@ -632,6 +647,11 @@ export interface Output {
 
 export declare const Output: OutputDecorator;
 
+export interface OutputDecorator {
+    (bindingPropertyName?: string): any;
+    new (bindingPropertyName?: string): any;
+}
+
 export declare const PACKAGE_ROOT_URL: InjectionToken<string>;
 
 export interface Pipe {
@@ -640,6 +660,11 @@ export interface Pipe {
 }
 
 export declare const Pipe: PipeDecorator;
+
+export interface PipeDecorator {
+    (obj: Pipe): TypeDecorator;
+    new (obj: Pipe): Pipe;
+}
 
 export interface PipeTransform {
     transform(value: any, ...args: any[]): any;


### PR DESCRIPTION
…ocumented (#28836)

If an interface is not exported publicly from its package, then the doc-gen
does not see it, and so cannot include it in the generated documentation.

This was the case for a number of `...Decorator` interfaces, such as
`PipeDecorator` and `InputDecorator.

This commit adds these interfaces to the public export to fix this problem.

PR Close #28836

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
