### PR TITLE
Create a new pull request by comparing changes across two branches

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -367,9 +367,11 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
         assertEmptyWidthAndHeight(this);
       } else {
         assertNonEmptyWidthAndHeight(this);
+        // Only check for distorted images when not in fill mode, where
+        // images may be intentionally stretched, cropped or letterboxed.
+        assertNoImageDistortion(this, this.imgElement, this.renderer);
       }
       assertValidLoadingInput(this);
-      assertNoImageDistortion(this, this.imgElement, this.renderer);
       if (!this.ngSrcset) {
         assertNoComplexSizes(this);
       }

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
@@ -36,6 +36,10 @@ import {Component} from '@angular/core';
      <!-- Aspect-ratio: 1.0652173913 -->
      <img ngSrc="/e2e/b.png" width="245" height="230">
      <br>
+     <!-- Fill mode disables aspect ratio warning -->
+     <!-- Aspect-ratio: 0.1 -->
+     <img ngSrc="/e2e/b.png" width="24" height="240" disableOptimizedSrcset fill>
+     <br>
      <!-- Supplied aspect ratio is correct & image has 0x0 rendered size -->
      <img ngSrc="/e2e/a.png" width="25" height="25" style="display: none">
      <br>


### PR DESCRIPTION
…d (#47824)

The image distortion warning (when rendered aspect ratio is noticeably different than intrinsic) doesn't make sense with fill mode, where the user may want the image to stretch, crop or letterbox.

PR Close #47824

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
